### PR TITLE
Fixed broken Back button

### DIFF
--- a/LTNavigationBar/UINavigationBar+BackgroundColor.m
+++ b/LTNavigationBar/UINavigationBar+BackgroundColor.m
@@ -29,6 +29,7 @@ static char const * const overlayKey = "backgroundOverlay";
         [self setBackgroundImage:[UIImage new] forBarMetrics:UIBarMetricsDefault];
         [self setShadowImage:[UIImage new]];
         self.overlay = [[UIView alloc] initWithFrame:CGRectMake(0, -20, [UIScreen mainScreen].bounds.size.width, 64)];
+        self.overlay.userInteractionEnabled = NO;
         [self insertSubview:self.overlay atIndex:0];
     }
     self.overlay.backgroundColor = backgroundColor;


### PR DESCRIPTION
Fix for Issue #1: when LTNavigationBar is used for view controller that has Back button - it can't be used because overlay intercepts all touches.
 