### PR TITLE
fix a view_controller's first load

### DIFF
--- a/LTNavigationBar/UINavigationBar+Awesome.m
+++ b/LTNavigationBar/UINavigationBar+Awesome.m
@@ -51,6 +51,13 @@ static char overlayKey;
     
     UIView *titleView = [self valueForKey:@"_titleView"];
     titleView.alpha = alpha;
+//    when viewController first load, the titleView maybe nil
+    [[self subviews] enumerateObjectsUsingBlock:^(UIView *obj, NSUInteger idx, BOOL *stop) {
+        if ([obj isKindOfClass:NSClassFromString(@"UINavigationItemView")]) {
+            obj.alpha = alpha;
+            *stop = YES;
+        }
+    }];
 }
 
 - (void)lt_reset


### PR DESCRIPTION
When first load, the `_titleView` of a `UINavigationBar` maybe `nil`, but it has a subview whose class is `UINavigationItemView`

- original pic

![image](https://cloud.githubusercontent.com/assets/7866087/11263006/4437b272-8ec1-11e5-8745-c8ab549645c4.png)
- use your current code

![image](https://cloud.githubusercontent.com/assets/7866087/11263012/553ef2ec-8ec1-11e5-86ab-042cc736e0a0.png)
- fixed by this request

![image](https://cloud.githubusercontent.com/assets/7866087/11263016/684516aa-8ec1-11e5-9575-1cea56899ebb.png)