### PR TITLE
Change width in frame for overlay view

### DIFF
--- a/LTNavigationBar/UINavigationBar+Awesome.m
+++ b/LTNavigationBar/UINavigationBar+Awesome.m
@@ -26,7 +26,7 @@ static char overlayKey;
 {
     if (!self.overlay) {
         [self setBackgroundImage:[UIImage new] forBarMetrics:UIBarMetricsDefault];
-        self.overlay = [[UIView alloc] initWithFrame:CGRectMake(0, -20, [UIScreen mainScreen].bounds.size.width, CGRectGetHeight(self.bounds) + 20)];
+        self.overlay = [[UIView alloc] initWithFrame:CGRectMake(0, -20, CGRectGetWidth(self.bounds), CGRectGetHeight(self.bounds) + 20)];
         self.overlay.userInteractionEnabled = NO;
         self.overlay.autoresizingMask = UIViewAutoresizingFlexibleWidth|UIViewAutoresizingFlexibleHeight;
         [self insertSubview:self.overlay atIndex:0];


### PR DESCRIPTION
There's a problem in iOS7 when opening view controller in landscape. Overlay gets width from screen's width which is 320px for iPhone 4 and not 480px which is expected. Setting width to self.bounds' width resolves this issue.